### PR TITLE
redisio > 1.7.1 changes the way it should be included.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,7 +59,7 @@ default['gitlab']['install_ruby'] = '1.9.3-p484'
 default['gitlab']['install_ruby_path'] = node['gitlab']['home']
 default['gitlab']['cookbook_dependencies'] = %w(
   zlib readline ncurses openssh
-  logrotate redisio::install redisio::enable ruby_build
+  logrotate redisio::default redisio::enable ruby_build
 )
 
 # Required packages for Gitlab


### PR DESCRIPTION
* Include default instead install recipe.

Related to #83 