### PR TITLE
Upgrade to Gitlab 7-7-stable branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.1.0
 install: bundle install --without integration
 script: bundle exec rake

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -68,11 +68,13 @@ when 'debian'
   default['gitlab']['packages'] = %w(
     libyaml-dev libssl-dev libgdbm-dev libffi-dev checkinstall
     curl libcurl4-openssl-dev libicu-dev wget python-docutils sudo
+    cmake libkrb5-dev pkg-config
   )
 when 'rhel'
   default['gitlab']['packages'] = %w(
     libyaml-devel openssl-devel gdbm-devel libffi-devel
     curl libcurl-devel libicu-devel wget python-docutils sudo
+    cmake libkrb5-dev pkgconfig
   )
 else
   default['gitlab']['install_ruby'] = 'package'
@@ -86,7 +88,7 @@ else
     zlib1g-dev libyaml-dev libssl-dev libgdbm-dev
     libreadline-dev libncurses5-dev libffi-dev curl git-core openssh-server
     redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev
-    libicu-dev python-docutils sudo
+    libicu-dev python-docutils sudo cmake libkrb5-dev pkg-config
   )
 end
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,7 +59,7 @@ default['gitlab']['install_ruby'] = '1.9.3-p484'
 default['gitlab']['install_ruby_path'] = node['gitlab']['home']
 default['gitlab']['cookbook_dependencies'] = %w(
   zlib readline ncurses openssh
-  logrotate redisio::install redisio::enable ruby_build
+  logrotate redisio::install redisio::configure redisio::enable ruby_build
 )
 
 # Required packages for Gitlab
@@ -80,7 +80,7 @@ else
   default['gitlab']['install_ruby'] = 'package'
   default['gitlab']['cookbook_dependencies'] = %w(
     openssh readline zlib ruby_build
-    redisio::install redisio::enable
+    redisio::install redisio::configure redisio::enable
   )
   default['gitlab']['packages'] = %w(
     autoconf binon flex gcc gcc-c++ make m4

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,12 +35,12 @@ default['gitlab']['username_changing_enabled'] = true
 
 # Set github URL for gitlab
 default['gitlab']['git_url'] = 'git://github.com/gitlabhq/gitlabhq.git'
-default['gitlab']['git_branch'] = '6-9-stable'
+default['gitlab']['git_branch'] = '7-7-stable'
 
 # gitlab-shell attributes
 default['gitlab']['shell']['home'] = node['gitlab']['home'] + '/gitlab-shell'
 default['gitlab']['shell']['git_url'] = 'git://github.com/gitlabhq/gitlab-shell.git'
-default['gitlab']['shell']['git_branch'] = 'v1.9.4'
+default['gitlab']['shell']['git_branch'] = 'v2.4.1'
 
 # Database setup
 default['gitlab']['database']['type'] = 'mysql'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,9 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 name 'gitlab'
 version '6.9.0'
 
-%w(build-essential zlib readline ncurses git openssh redisio xml
+depends 'redisio', '>= 2.1.0'
+
+%w(build-essential zlib readline ncurses git openssh xml
    ruby_build certificate database logrotate mysql nginx
    postgresql apt yum-epel).each do |cb_depend|
   depends cb_depend

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'gitlab::default' do
-
   before do
     stub_command('git --version >/dev/null').and_return(true)
     stub_command('which nginx').and_return(true)
@@ -9,7 +8,7 @@ describe 'gitlab::default' do
 
   context 'on Centos 6.5 with mysql and https' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'centos', version: 6.5) do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.override['gitlab']['database']['type'] = 'mysql'
         node.override['mysql']['server_root_password'] = 'test'
         node.override['gitlab']['https'] = true
@@ -57,7 +56,7 @@ describe 'gitlab::default' do
 
   context 'on Centos 6.5 with postgres and http' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'centos', version: 6.5) do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.override['gitlab']['database']['type'] = 'postgres'
         node.override['gitlab']['web_fqdn'] = 'gitlab.example.com'
       end.converge(described_recipe)
@@ -103,7 +102,7 @@ describe 'gitlab::default' do
 
   context 'on centos 6.5 with /srv/git home, and default install_ruby_path' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'centos', version: 6.5) do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.override['mysql']['server_root_password'] = 'test'
         node.override['gitlab']['home'] = '/srv/git'
       end.converge(described_recipe)
@@ -126,7 +125,7 @@ describe 'gitlab::default' do
 
   context 'on centos 6.5 with /srv/git home, and /var/lib/git install_ruby_path' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'centos', version: '6.5') do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5') do |node|
         node.override['mysql']['server_root_password'] = 'test'
         node.override['gitlab']['home'] = '/srv/git'
         node.override['gitlab']['install_ruby_path'] = '/var/lib/git'
@@ -150,7 +149,7 @@ describe 'gitlab::default' do
 
   context 'on centos 6.5 with Ruby package' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'centos', version: '6.5') do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5') do |node|
         node.override['mysql']['server_root_password'] = 'test'
         node.override['gitlab']['install_ruby'] = 'package'
       end.converge(described_recipe)

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -11,6 +11,7 @@ describe 'gitlab::default' do
     let(:chef_run) do
       ChefSpec::Runner.new(platform: 'centos', version: 6.5) do |node|
         node.override['gitlab']['database']['type'] = 'mysql'
+        node.override['mysql']['server_root_password'] = 'test'
         node.override['gitlab']['https'] = true
         node.override['gitlab']['web_fqdn'] = 'gitlab.example.com'
       end.converge(described_recipe)
@@ -103,6 +104,7 @@ describe 'gitlab::default' do
   context 'on centos 6.5 with /srv/git home, and default install_ruby_path' do
     let(:chef_run) do
       ChefSpec::Runner.new(platform: 'centos', version: 6.5) do |node|
+        node.override['mysql']['server_root_password'] = 'test'
         node.override['gitlab']['home'] = '/srv/git'
       end.converge(described_recipe)
     end
@@ -125,6 +127,7 @@ describe 'gitlab::default' do
   context 'on centos 6.5 with /srv/git home, and /var/lib/git install_ruby_path' do
     let(:chef_run) do
       ChefSpec::Runner.new(platform: 'centos', version: '6.5') do |node|
+        node.override['mysql']['server_root_password'] = 'test'
         node.override['gitlab']['home'] = '/srv/git'
         node.override['gitlab']['install_ruby_path'] = '/var/lib/git'
       end.converge(described_recipe)
@@ -148,6 +151,7 @@ describe 'gitlab::default' do
   context 'on centos 6.5 with Ruby package' do
     let(:chef_run) do
       ChefSpec::Runner.new(platform: 'centos', version: '6.5') do |node|
+        node.override['mysql']['server_root_password'] = 'test'
         node.override['gitlab']['install_ruby'] = 'package'
       end.converge(described_recipe)
     end


### PR DESCRIPTION
I've tried to keep changes to a minimum in this PR. This update:

* bumps the git version for `gitlab` and `gitlab-shell` to their latest stable
* adds package dependencies introduced by gitlab [as specified here](https://github.com/gitlabhq/gitlabhq/blob/master/doc/update/upgrader.md#2-run-gitlab-upgrade-tool)
* fixes `redisio` cookbook forwards compatibility issues. Requiring 2.1.0+ was the cleanest way to do this, though support of older is also possible
* Fixes chefspec failures due to missing mysql attributes
* Fixes travis build by requiring ruby 2.1.0 (needed to install latest ohai)
* Tidies linting issues, and deprecations from latest foodcritic and chefspec
