### PR TITLE
Socket for mysql connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ is calculated.
   - Options: "mysql", "postgresql"
   - Default (varies based on `type`)
 
+* `gitlab['database']['socket']`
+  - The socket to use for connection
+  - Default /var/run/mysqld/mysqld.sock
+
 * `gitlab['database']['encoding']`
   - The database encoding
   - Default (varies based on `type`)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,6 +48,7 @@ default['gitlab']['database']['adapter'] = node['gitlab']['database']['type'] ==
 default['gitlab']['database']['encoding'] = node['gitlab']['database']['type'] == 'mysql' ? 'utf8' : 'unicode'
 default['gitlab']['database']['collation'] = 'utf8_general_ci'
 default['gitlab']['database']['host'] = '127.0.0.1'
+default['gitlab']['database']['socket'] = '/var/run/mysqld/mysqld.sock'
 default['gitlab']['database']['pool'] = 5
 default['gitlab']['database']['database'] = 'gitlab'
 default['gitlab']['database']['username'] = 'gitlab'

--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -45,10 +45,12 @@ database_user = node['gitlab']['database']['username']
 database_password = node['gitlab']['database']['password']
 database_userhost = node['gitlab']['database']['userhost']
 database_host = node['gitlab']['database']['host']
+database_host = node['gitlab']['database']['socket']
 database_connection = {
   host: database_host,
   username: 'root',
-  password: node['mysql']['server_root_password']
+  password: node['mysql']['server_root_password'],
+  socket: node['mysql']['socket']
 }
 
 # Create the database


### PR DESCRIPTION
Hello,

Add the feature to define the socket for the mysql connection. Very useful with the new mysql gem which define mysql instances with a name and the socket is located to `/var/run/mysql-default/mysqld.sock`

