### PR TITLE
Redis instance name can be customized by attributes.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,6 +63,9 @@ default['gitlab']['cookbook_dependencies'] = %w(
   logrotate redisio::default redisio::enable ruby_build
 )
 
+# Redisio instance name
+default['gitlab']['redis_instance'] = 'redis-server'
+
 # Required packages for Gitlab
 case node['platform_family']
 when 'debian'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -353,9 +353,9 @@ nginx_site 'gitlab' do
 end
 
 # Disable default site
-nginx_site 'default' do
-  enable false
-end
+#nginx_site 'default' do
+#  enable false
+#end
 
 # Enable and start unicorn and sidekiq service
 service 'gitlab' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -174,7 +174,8 @@ template '/etc/init.d/gitlab' do
   source 'gitlab.init.erb'
   variables(
     gitlab_app_home: node['gitlab']['app_home'],
-    gitlab_user: node['gitlab']['user']
+    gitlab_user: node['gitlab']['user'],
+    gitlab_redis_instance: node['gitlab']['redis_instance']
   )
 end
 

--- a/templates/default/gitlab.init.erb
+++ b/templates/default/gitlab.init.erb
@@ -6,7 +6,7 @@
 
 ### BEGIN INIT INFO
 # Provides:          gitlab
-# Required-Start:    $local_fs $remote_fs $network $syslog redis-server
+# Required-Start:    $local_fs $remote_fs $network $syslog <%= @gitlab_redis_instance %>
 # Required-Stop:     $local_fs $remote_fs $network $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
I have found that on my Ubuntu 15.04 there is no `redis-server` but `redis6379` instance created by default.
Because of that the gitlab init script is failing, so I added `node['gitlab']['redis_instance']`attribute (default is still `redis-server`) to address this issue.