### PR TITLE
Enable the user to choose whether the LDAP server is AD

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,6 +113,7 @@ default['gitlab']['ldap']['enabled'] = false
 default['gitlab']['ldap']['host'] = '_your_ldap_server'
 default['gitlab']['ldap']['base'] = '_the_base_where_you_search_for_users'
 default['gitlab']['ldap']['port'] = 636
+default['gitlab']['ldap']['active_directory'] = true
 default['gitlab']['ldap']['uid'] = 'sAMAccountName'
 default['gitlab']['ldap']['method'] = 'ssl'
 default['gitlab']['ldap']['bind_dn'] = '_the_full_dn_of_the_user_you_will_bind_with'

--- a/templates/default/gitlab.yml.erb
+++ b/templates/default/gitlab.yml.erb
@@ -141,7 +141,7 @@ production: &base
         # This setting specifies if LDAP server is Active Directory LDAP server.
         # For non AD servers it skips the AD specific queries.
         # If your LDAP server is not AD, set this to false.
-        active_directory: true
+        active_directory: <%= node['gitlab']['ldap']['active_directory'] %>
 
         # If allow_username_or_email_login is enabled, GitLab will ignore everything
         # after the first '@' in the LDAP username submitted by the user on login.


### PR DESCRIPTION
This pull request introduces a new configuration option `node['gitlab']['ldap']['active_directory']`, which is used in `gitlab.yml` instead of hard-coding it.