### PR TITLE
A JS runtime is needed in recent versions

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,13 +69,13 @@ when 'debian'
   default['gitlab']['packages'] = %w(
     libyaml-dev libssl-dev libgdbm-dev libffi-dev checkinstall
     curl libcurl4-openssl-dev libicu-dev wget python-docutils sudo
-    cmake libkrb5-dev pkg-config
+    cmake libkrb5-dev pkg-config nodejs
   )
 when 'rhel'
   default['gitlab']['packages'] = %w(
     libyaml-devel openssl-devel gdbm-devel libffi-devel
     curl libcurl-devel libicu-devel wget python-docutils sudo
-    cmake krb5-devel pkgconfig
+    cmake krb5-devel pkgconfig nodejs
   )
 else
   default['gitlab']['install_ruby'] = 'package'
@@ -89,7 +89,7 @@ else
     zlib1g-dev libyaml-dev libssl-dev libgdbm-dev
     libreadline-dev libncurses5-dev libffi-dev curl git-core openssh-server
     redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev
-    libicu-dev python-docutils sudo libkrb5-dev pkg-config
+    libicu-dev python-docutils sudo libkrb5-dev pkg-config nodejs
   )
 end
 


### PR DESCRIPTION
This is often provided by a gem like therubyracer but this means altering the Gemfile, which has consequences, and Node.js is considered a superior alternative so install that instead.