### PR TITLE
Use attribute to disable nginx default site

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -126,3 +126,6 @@ default['gitlab']['gravatar']['enabled'] = true
 # Mysql
 default['mysql']['server_root_password'] = 'Ch4ngm3'
 default['build-essential']['compile_time'] = true # needed for mysql chef_gem
+
+# nginx
+default['nginx']['default_site_enabled'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,12 +7,13 @@ name 'gitlab'
 version '7.7.1'
 
 %w(build-essential zlib readline ncurses git openssh redisio xml
-   ruby_build certificate database logrotate nginx
+   ruby_build certificate database logrotate
    postgresql apt yum-epel).each do |cb_depend|
   depends cb_depend
 end
 depends 'mysql', '~> 6.0'
 depends 'mysql2_chef_gem'
+depends 'nginx', '<3'
 
 %w(redhat centos scientific amazon debian ubuntu).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -351,11 +351,6 @@ nginx_site 'gitlab' do
   enable true
 end
 
-# Disable default site
-nginx_site 'default' do
-  enable false
-end
-
 # Enable and start unicorn and sidekiq service
 service 'gitlab' do
   priority 30


### PR DESCRIPTION
I noticed that the default site was flip-flopping on and off during the Chef run. Also restrict nginx cookbook to <3 because it is being rewritten.