### PR TITLE
mysql cookbook uses LWRP from v6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ override_attributes "gitlab" => {
   "https" => true,
   "certificate_databag_id" => "wildcard"
 }
-run_list "recipe[mysql::server]", "recipe[gitlab]
+run_list "recipe[gitlab]"
 ```
 
 License and Author


### PR DESCRIPTION
Followed the example role of README and got following error:
```
could not find recipe server for mysql
```
turns out gitlab cookbook already using LWRP and there is no need to install mysql via recipe