### PR TITLE
gitlab, gitlab-shell and Ruby bumps

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,12 +25,12 @@ platforms:
   #attributes:
     #apt:
     #- compile_time_update: true
-- name: centos-7.1
+- name: centos-7.2
   driver_config:
     network:
     - ["forwarded_port", {guest: 80, host: 8082}]
     - ["forwarded_port", {guest: 443, host: 8445}]
-- name: centos-6.6
+- name: centos-6.7
   driver_config:
     network:
     - ["forwarded_port", {guest: 80, host: 8083}]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 LineLength:
     Max: 125
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
     Exclude:
     - metadata.rb
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,12 +36,12 @@ default['gitlab']['username_changing_enabled'] = true
 
 # Set github URL for gitlab
 default['gitlab']['git_url'] = 'git://github.com/gitlabhq/gitlabhq.git'
-default['gitlab']['git_branch'] = '8-0-stable'
+default['gitlab']['git_branch'] = '8-5-stable'
 
 # gitlab-shell attributes
 default['gitlab']['shell']['home'] = node['gitlab']['home'] + '/gitlab-shell'
 default['gitlab']['shell']['git_url'] = 'git://github.com/gitlabhq/gitlab-shell.git'
-default['gitlab']['shell']['git_branch'] = 'v2.6.5'
+default['gitlab']['shell']['git_branch'] = 'v2.6.10'
 default['gitlab']['shell']['gitlab_host'] = nil
 
 # Database setup
@@ -59,7 +59,7 @@ default['gitlab']['postgresql']['username'] = 'postgres'
 # Ruby setup
 include_attribute 'ruby_build'
 default['ruby_build']['upgrade'] = 'sync'
-default['gitlab']['install_ruby'] = '2.1.6'
+default['gitlab']['install_ruby'] = '2.1.8'
 default['gitlab']['install_ruby_path'] = node['gitlab']['home']
 default['gitlab']['cookbook_dependencies'] = %w(
   zlib readline ncurses openssh

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ description 'Installs/Configures gitlab'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 name 'gitlab'
 version '8.0.2'
+issues_url 'https://github.com/atomic-penguin/cookbook-gitlab/issues'
+source_url 'https://github.com/atomic-penguin/cookbook-gitlab'
 
 %w(build-essential zlib readline ncurses git openssh redisio xml
    ruby_build certificate database logrotate


### PR DESCRIPTION
I tried bumping these to their latest versions (still Ruby 2.1) and everything went smoothly under default-centos-72. I've only tried registering and clicking around so far so if you want to wait till we've upgraded our production server, that's fine. I still need to fix an SELinux issue before we do that.