### PR TITLE
Configure the SSL protocols and ciphers via attributes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,12 +25,12 @@ platforms:
   #attributes:
     #apt:
     #- compile_time_update: true
-- name: centos-7.1
+- name: centos-7.2
   driver_config:
     network:
     - ["forwarded_port", {guest: 80, host: 8082}]
     - ["forwarded_port", {guest: 443, host: 8445}]
-- name: centos-6.6
+- name: centos-6.7
   driver_config:
     network:
     - ["forwarded_port", {guest: 80, host: 8083}]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 LineLength:
     Max: 125
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
     Exclude:
     - metadata.rb
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,12 +36,12 @@ default['gitlab']['username_changing_enabled'] = true
 
 # Set github URL for gitlab
 default['gitlab']['git_url'] = 'git://github.com/gitlabhq/gitlabhq.git'
-default['gitlab']['git_branch'] = '8-0-stable'
+default['gitlab']['git_branch'] = '8-5-stable'
 
 # gitlab-shell attributes
 default['gitlab']['shell']['home'] = node['gitlab']['home'] + '/gitlab-shell'
 default['gitlab']['shell']['git_url'] = 'git://github.com/gitlabhq/gitlab-shell.git'
-default['gitlab']['shell']['git_branch'] = 'v2.6.5'
+default['gitlab']['shell']['git_branch'] = 'v2.6.10'
 default['gitlab']['shell']['gitlab_host'] = nil
 
 # Database setup
@@ -59,7 +59,7 @@ default['gitlab']['postgresql']['username'] = 'postgres'
 # Ruby setup
 include_attribute 'ruby_build'
 default['ruby_build']['upgrade'] = 'sync'
-default['gitlab']['install_ruby'] = '2.1.6'
+default['gitlab']['install_ruby'] = '2.1.8'
 default['gitlab']['install_ruby_path'] = node['gitlab']['home']
 default['gitlab']['cookbook_dependencies'] = %w(
   zlib readline ncurses openssh

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -107,6 +107,10 @@ default['gitlab']['self_signed_cert'] = false
 default['gitlab']['ssl_certificate'] = "/etc/nginx/ssl/certs/#{node['fqdn']}.pem"
 default['gitlab']['ssl_certificate_key'] = "/etc/nginx/ssl/private/#{node['fqdn']}.key"
 
+# Backwards compatible ciphers needed for Java IDEs
+default['gitlab']['ssl_ciphers'] = 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4'
+default['gitlab']['ssl_protocols'] = 'TLSv1 TLSv1.1 TLSv1.2'
+
 default['gitlab']['backup_path'] = node['gitlab']['app_home'] + '/backups'
 default['gitlab']['backup_keep_time'] = 604_800
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ description 'Installs/Configures gitlab'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 name 'gitlab'
 version '8.0.2'
+issues_url 'https://github.com/atomic-penguin/cookbook-gitlab/issues'
+source_url 'https://github.com/atomic-penguin/cookbook-gitlab'
 
 %w(build-essential zlib readline ncurses git openssh redisio xml
    ruby_build certificate database logrotate

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -471,6 +471,8 @@ template '/etc/nginx/sites-available/gitlab' do
     https_boolean: node['gitlab']['https'],
     ssl_certificate: node['gitlab']['ssl_certificate'],
     ssl_certificate_key: node['gitlab']['ssl_certificate_key'],
+    ssl_ciphers: node['gitlab']['ssl_ciphers'],
+    ssl_protocols: node['gitlab']['ssl_protocols'],
     listen: "#{node['gitlab']['listen_ip']}:#{listen_port}"
   )
 end

--- a/templates/default/nginx.gitlab.erb
+++ b/templates/default/nginx.gitlab.erb
@@ -83,9 +83,8 @@ server {
   ssl_certificate <%= @ssl_certificate %>;
   ssl_certificate_key <%= @ssl_certificate_key %>;
 
-  # GitLab needs backwards compatible ciphers to retain compatibility with Java IDEs
-  ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers <%= @ssl_ciphers %>;
+  ssl_protocols <%= @ssl_protocols %>;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
   ssl_session_timeout 5m;


### PR DESCRIPTION
I would normally use the nginx cookbook's extra_configs attribute for this but the template already specifies these, overriding anything I might put in the global configuration.

While the current cipher list looks reasonable, recent security practices make it important for cookbook users to be able to choose their own cipher list.