### PR TITLE
Locate redis-cli using a redisio cookbook attribute

### DIFF
--- a/templates/default/shell_config.yml.erb
+++ b/templates/default/shell_config.yml.erb
@@ -20,7 +20,7 @@ auth_file: <%= node['gitlab']['home'] + "/.ssh/authorized_keys"%>
 
 # Redis settings used for pushing commit notices to gitlab
 redis:
-  bin: /usr/local/bin/redis-cli
+  bin: <%= node['redisio']['bin_path'] %>/redis-cli
   host: 127.0.0.1
   port: 6379
   # socket: /tmp/redis.socket # Only define this if you want to use sockets


### PR DESCRIPTION
This fixes gitlab-shell when installing Redis from a package.