### PR TITLE
allow setup of database to be disabled with attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,6 +45,7 @@ default['gitlab']['shell']['git_branch'] = 'v2.6.10'
 default['gitlab']['shell']['gitlab_host'] = nil
 
 # Database setup
+default['gitlab']['database']['configure'] = true
 default['gitlab']['database']['type'] = 'mysql'
 default['gitlab']['database']['adapter'] = node['gitlab']['database']['type'] == 'mysql' ? 'mysql2' : 'postgresql'
 default['gitlab']['database']['encoding'] = node['gitlab']['database']['type'] == 'mysql' ? 'utf8' : 'unicode'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -106,6 +106,7 @@ default['gitlab']['trust_local_sshkeys'] = 'yes'
 
 default['gitlab']['https'] = false
 default['gitlab']['certificate_databag_id'] = nil
+default['gitlab']['certificate_databag_type'] = 'encrypted'
 default['gitlab']['self_signed_cert'] = false
 default['gitlab']['ssl_certificate'] = "/etc/nginx/ssl/certs/#{node['fqdn']}.pem"
 default['gitlab']['ssl_certificate_key'] = "/etc/nginx/ssl/private/#{node['fqdn']}.key"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,13 +26,15 @@ when 'rhel'
 end
 
 # Setup the database connection
-case node['gitlab']['database']['type']
-when 'mysql'
-  include_recipe 'gitlab::mysql'
-when 'postgres'
-  include_recipe 'gitlab::postgres'
-else
-  Chef::Log.error "#{node['gitlab']['database']['type']} is not a valid type. Please use 'mysql' or 'postgres'!"
+if node['gitlab']['database']['configure']
+  case node['gitlab']['database']['type']
+  when 'mysql'
+    include_recipe 'gitlab::mysql'
+  when 'postgres'
+    include_recipe 'gitlab::postgres'
+  else
+    Chef::Log.error "#{node['gitlab']['database']['type']} is not a valid type. Please use 'mysql' or 'postgres'!"
+  end
 end
 
 # Install SELinux tools where appropriate

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -450,6 +450,7 @@ end
 # Look for `search_id` in data_bag `certificates`
 certificate_manage 'gitlab' do
   search_id node['gitlab']['certificate_databag_id']
+  data_bag_type node['gitlab']['certificate_databag_type']
   cert_path '/etc/nginx/ssl'
   owner node['gitlab']['user']
   group node['gitlab']['user']


### PR DESCRIPTION
The current way the recipe is written does not allow much flexibility for an installation using a remote database server. For example, if the gitlab application server does not have access to login to the database as root to setup the gitlab account and database or the administrator would choose not to for security purposes. Allowing the ability to disable the setup of the database with the attribute allows for the database to be configured on a different server.

Specifying the certificate databag type with an attribute would allow for usage with chef-vault. The default type is encrypted which is the default from the certificate cookbook.